### PR TITLE
Added github workflow for publishing container to GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,10 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
+        name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/release/}" >> $GITHUB_OUTPUT
+      -
         name: Build and push web filehost image to GHCR
         uses: docker/bake-action@v6
         with:
@@ -42,4 +46,4 @@ jobs:
                 docker-bake.hcl
             set: |
                 *.tags=ghcr.io/${{ github.repository_owner }}/filehost:latest
-                *.tags=ghcr.io/${{ github.repository_owner }}/filehost:${{ github.ref_name }}
+                *.tags=ghcr.io/${{ github.repository_owner }}/filehost:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,45 @@
+name: File Host Docker Build and Push GHCR
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    tags:
+      - release/**
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      - 
+        name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and push web filehost image to GHCR
+        uses: docker/bake-action@v6
+        with:
+            source: .
+            push: true
+            targets: default
+            files: |
+                docker-bake.hcl
+            set: |
+                *.tags=ghcr.io/${{ github.repository_owner }}/filehost:latest
+                *.tags=ghcr.io/${{ github.repository_owner }}/filehost:${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24-alpine
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Hit the Railway button and have your filehost up and running in a few minutes. T
 
 
 ### DIY - Docker! 🐳
-Simply run `docker-compose up --build -d` on your server after you've configured the `.env` and it's all up and running.
+Copy the `docker-compose.prod.yml`. 
+Simply run `docker compose -f .\docker-compose.prod.yml up` on your server after you've configured the `.env` and it's all up and running.
 
 ```
 Note: We're still actively working on the product and is currently in early alpha stages. We currently recommend also making a backup or chosing S3 as a host with the project.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,8 @@
+target "default" {
+  context = "."
+  dockerfile = "Dockerfile"
+  targets = ["build"]
+  tags = ["filehost:latest"]
+  no-cache = true
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    container_name: filehost
+    image: ghcr.io/filecoffee/filehost:latest # or use a specific tag
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${PORT}:${PORT}"
+    volumes:
+      - ./uploads:/usr/src/app/uploads
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production


### PR DESCRIPTION
Added a Github Actions workflow for publishing container to GHCR so you can easily create an image to be used on your server.

To initialize the action creates a git tag with the prefix release/ (so for example release/1.0.0), everything after the release/ becomes the tag for the docker container (so release/1.0.0 will publish a container with a tag filehost:1.0.0).

No configuration is needed for the actions, all secrets are managed by github (see the  github.actor and  secrets.GITHUB_TOKEN
in the workflow).

I have test it on my own fork: [Actions](https://github.com/lukasvdberk/filehost/actions)
With prebuilt images: [Build images by action](https://github.com/lukasvdberk/filehost/pkgs/container/filehost)

Also added a docker compose production example file that uses the prebuild image and adjusted the docs.

If there is anything I can do to make this PR work, let me know :)